### PR TITLE
audio.js; tweak; 

### DIFF
--- a/www/audio.js
+++ b/www/audio.js
@@ -19,17 +19,6 @@ $(document).ready(function() {
   });
 });
 
-Shiny.addCustomMessageHandler("startRecording", function(message) {
-  if (!recording) {
-    startRecording();
-  }
-});
-
-Shiny.addCustomMessageHandler("stopRecording", function(message) {
-  if (recording) {
-    stopRecording();
-  }
-});
 
 function startRecording() {
   recording = true;


### PR DESCRIPTION
Removes two no-longer-needed Shiny.addCustomMessageHandler calls from the javascript because now javascript starts and stops recording directly from the button clicks and does not need for shiny to detect the button click and then send it a separate message to start/stop recording. Of course server.R still needs to know when the buttons have been clicked, so that is all still the same. Only the javascript is altered in this commit.